### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,11 @@ RUN mkdir -p /app
 
 WORKDIR /app
 
+ENV NPM_CONFIG_CACHE=/home/node/.npm
+
 COPY package*.json ./
+
+RUN mkdir -p $NPM_CONFIG_CACHE && chown -R node:node $NPM_CONFIG_CACHE
 
 RUN npm install
 
@@ -15,5 +19,4 @@ RUN npm run build
 
 EXPOSE 3000
 
-# Start the app on port 4455 as recommended by ory
 CMD ["npm", "start", "--", "-p", "3000"]


### PR DESCRIPTION
- Getting this error:
```
npm ERR! Your cache folder contains root-owned files, due to a bug in
npm ERR! previous versions of npm which has since been addressed.
```
- This fixes npm cache permission issues by setting a new directory 
