### PR TITLE
Add Google Health connection confirmation

### DIFF
--- a/app/_lib/study/protocol/index.ts
+++ b/app/_lib/study/protocol/index.ts
@@ -88,12 +88,26 @@ export interface ArmtMetadataInbuilt extends ArmtMetadataBase {
   options: any
 }
 
+export type ConnectConfirmationItem = {
+  label?: string
+  description?: string
+}
+
+export type ConnectDeviceConfirmation = {
+  whatHappensNext?: string
+  dataSharedItems?: ConnectConfirmationItem[]
+  privacyPolicyUrl?: string
+  publicationsUrl?: string
+  adminEmail?: string
+}
+
 export type ConnectDeviceConfig = {
   id: string
   title: string
   description?: string
   guideUrl?: string
   videoUrl?: string
+  confirmation?: ConnectDeviceConfirmation
 }
 
 export type ArmtMetadata = ArmtMetadataGithub | ArmtMetadataInbuilt | ArmtMetadataLocal

--- a/app/_ui/components/device_connect/successBanner.tsx
+++ b/app/_ui/components/device_connect/successBanner.tsx
@@ -2,10 +2,7 @@
 import { Button, Modal, Box, Typography, Grow, Backdrop, Link } from "@mui/material";
 import { useRouter } from "next/navigation";
 import React from "react";
-
-const GOOGLE_PRIVACY_POLICY_URL = 'https://radar-base.org/google-privacy-policy/'
-const RADAR_PUBLICATIONS_URL = 'https://radar-base.org/publications/'
-const STUDY_ADMIN_EMAIL = 'radar-base@kcl.ac.uk'
+import { ConnectDeviceConfirmation } from "@/app/_lib/study/protocol";
 
 export function DeviceConnectedBanner(props: {device: string, onFinish?: () => {}}) {
   const [open, setOpen] = React.useState(true);
@@ -58,10 +55,10 @@ export function DeviceConnectedBanner(props: {device: string, onFinish?: () => {
   )
 }
 
-// A richer confirmation shown only for Google Health
-export function GoogleHealthConnectedBanner(props: {onFinish?: () => {}}) {
+export function GoogleHealthConnectedBanner(props: {confirmation: ConnectDeviceConfirmation, onFinish?: () => {}}) {
   const [open, setOpen] = React.useState(true);
   const router = useRouter()
+  const { confirmation } = props
   const handleAddMore = () => {
     setOpen(false)
     router.replace(window.location.href.split('?')[0])
@@ -97,37 +94,42 @@ export function GoogleHealthConnectedBanner(props: {onFinish?: () => {}}) {
             Thank you for authorizing your account. Your health and fitness data is now being securely transmitted to the RADAR-base research platform.
           </Typography>
 
-          <Typography variant="subtitle1" fontWeight={600} sx={{ mt: 3 }}>What happens next?</Typography>
-          <Typography variant="body2" sx={{ mt: 1 }}>
-            To maintain the scientific integrity of this study and prevent bias, this portal does not display your collected health data. Your information is securely routed directly to our clinical research team for analysis.
-          </Typography>
+          {confirmation.whatHappensNext && (
+            <>
+              <Typography variant="subtitle1" fontWeight={600} sx={{ mt: 3 }}>What happens next?</Typography>
+              <Typography variant="body2" sx={{ mt: 1 }}>{confirmation.whatHappensNext}</Typography>
+            </>
+          )}
 
-          <Typography variant="subtitle1" fontWeight={600} sx={{ mt: 3 }}>Data currently being shared</Typography>
-          <Typography variant="body2" sx={{ mt: 1 }}>
-            As agreed in the consent step, researchers have read-only access to your:
-          </Typography>
-          <Box component="ul" sx={{ pl: 3, mt: 1, mb: 0 }}>
-            <Typography component="li" variant="body2"><strong>Activity &amp; Fitness:</strong> Steps, total calories, and exercise sessions.</Typography>
-            <Typography component="li" variant="body2"><strong>Health Metrics:</strong> Heart rate, HRV, blood oxygen (oxy-heart-rate), sleep respiratory rate, and sleep temperature derivations.</Typography>
-            <Typography component="li" variant="body2"><strong>Sleep:</strong> Sleep stages and classic sleep data.</Typography>
-            <Typography component="li" variant="body2"><strong>Heart Health:</strong> Electrocardiogram (raw waveform) and irregular rhythm notifications (AFib).</Typography>
-            <Typography component="li" variant="body2"><strong>Location:</strong> GPS trackpoints (collected only during active exercise).</Typography>
-            <Typography component="li" variant="body2"><strong>Settings:</strong> Timezone information (to accurately align your daily data).</Typography>
-          </Box>
+          {confirmation.dataSharedItems && confirmation.dataSharedItems.length > 0 && (
+            <>
+              <Typography variant="subtitle1" fontWeight={600} sx={{ mt: 3 }}>Data currently being shared</Typography>
+              <Typography variant="body2" sx={{ mt: 1 }}>
+                As agreed in the consent step, researchers have read-only access to your:
+              </Typography>
+              <Box component="ul" sx={{ pl: 3, mt: 1, mb: 0 }}>
+                {confirmation.dataSharedItems.map((item, i) => (
+                  <Typography component="li" variant="body2" key={i}>
+                    {item.label && <strong>{item.label}{item.description ? ': ' : ''}</strong>}{item.description}
+                  </Typography>
+                ))}
+              </Box>
+            </>
+          )}
 
           <Typography variant="subtitle1" fontWeight={600} sx={{ mt: 3 }}>Managing your connection</Typography>
           <Typography variant="body2" sx={{ mt: 1 }}>
             Participation is entirely voluntary. If you wish to withdraw from the study or disconnect your Google Health account, please contact the study administration team at{' '}
-            <Link href={`mailto:${STUDY_ADMIN_EMAIL}`}>{STUDY_ADMIN_EMAIL}</Link>.
+            <Link href={`mailto:${confirmation.adminEmail}`}>{confirmation.adminEmail}</Link>.
           </Typography>
 
           <Typography variant="subtitle1" fontWeight={600} sx={{ mt: 3 }}>Learn more about our work</Typography>
           <Box component="ul" sx={{ pl: 3, mt: 1, mb: 0 }}>
             <Typography component="li" variant="body2">
-              <Link href={GOOGLE_PRIVACY_POLICY_URL} target="_blank" rel="noopener noreferrer">How we handle your data (Google Privacy Policy)</Link>
+              <Link href={confirmation.privacyPolicyUrl} target="_blank" rel="noopener noreferrer">How we handle your data (Google Privacy Policy)</Link>
             </Typography>
             <Typography component="li" variant="body2">
-              <Link href={RADAR_PUBLICATIONS_URL} target="_blank" rel="noopener noreferrer">View our peer-reviewed research publications</Link>
+              <Link href={confirmation.publicationsUrl} target="_blank" rel="noopener noreferrer">View our peer-reviewed research publications</Link>
             </Typography>
           </Box>
 

--- a/app/_ui/components/device_connect/successBanner.tsx
+++ b/app/_ui/components/device_connect/successBanner.tsx
@@ -1,7 +1,11 @@
 "use client"
-import { Button, Modal, Box, Typography, Grow, Backdrop } from "@mui/material";
+import { Button, Modal, Box, Typography, Grow, Backdrop, Link } from "@mui/material";
 import { useRouter } from "next/navigation";
 import React from "react";
+
+const GOOGLE_PRIVACY_POLICY_URL = 'https://radar-base.org/google-privacy-policy/'
+const RADAR_PUBLICATIONS_URL = 'https://radar-base.org/publications/'
+const STUDY_ADMIN_EMAIL = 'radar-base@kcl.ac.uk'
 
 export function DeviceConnectedBanner(props: {device: string, onFinish?: () => {}}) {
   const [open, setOpen] = React.useState(true);
@@ -44,9 +48,92 @@ export function DeviceConnectedBanner(props: {device: string, onFinish?: () => {
           <Typography sx={{ mt: 2 }}>
             {`You have successfully linked your ${props.device}.\n\nAre you done, or would you like to link another device?`}
           </Typography>
-          <Box display={'flex'} flexDirection={'row'} justifyContent={'flex-end'} marginTop={2} gap={1}> 
+          <Box display={'flex'} flexDirection={'row'} justifyContent={'flex-end'} marginTop={2} gap={1}>
             <Button onClick={handleAddMore} variant="outlined">Link another device</Button>
             <Button onClick={handleReturn} variant="outlined">Done</Button>
+          </Box>
+        </Box>
+      </Grow>
+    </Backdrop>
+  )
+}
+
+// A richer confirmation shown only for Google Health
+export function GoogleHealthConnectedBanner(props: {onFinish?: () => {}}) {
+  const [open, setOpen] = React.useState(true);
+  const router = useRouter()
+  const handleAddMore = () => {
+    setOpen(false)
+    router.replace(window.location.href.split('?')[0])
+  }
+  const handleReturn = () => {
+    setOpen(false)
+    if (props.onFinish) {
+      props.onFinish()
+    } else {
+      router.push('./')
+    }
+  }
+  return (
+    <Backdrop
+      sx={(theme: any) => ({ zIndex: theme.zIndex.drawer + 1 })}
+      open={open}
+    >
+      <Grow in={open}>
+        <Box sx={{
+          position: 'relative',
+          width: '90%',
+          maxWidth: 640,
+          maxHeight: '85vh',
+          overflowY: 'auto',
+          bgcolor: 'background.paper',
+          borderRadius: 2,
+          boxShadow: 16,
+          p: 4,
+          textAlign: 'left',
+        }}>
+          <Typography variant="h3">Google Health Successfully Connected</Typography>
+          <Typography variant="body2" sx={{ mt: 2 }}>
+            Thank you for authorizing your account. Your health and fitness data is now being securely transmitted to the RADAR-base research platform.
+          </Typography>
+
+          <Typography variant="subtitle1" fontWeight={600} sx={{ mt: 3 }}>What happens next?</Typography>
+          <Typography variant="body2" sx={{ mt: 1 }}>
+            To maintain the scientific integrity of this study and prevent bias, this portal does not display your collected health data. Your information is securely routed directly to our clinical research team for analysis.
+          </Typography>
+
+          <Typography variant="subtitle1" fontWeight={600} sx={{ mt: 3 }}>Data currently being shared</Typography>
+          <Typography variant="body2" sx={{ mt: 1 }}>
+            As agreed in the consent step, researchers have read-only access to your:
+          </Typography>
+          <Box component="ul" sx={{ pl: 3, mt: 1, mb: 0 }}>
+            <Typography component="li" variant="body2"><strong>Activity &amp; Fitness:</strong> Steps, total calories, and exercise sessions.</Typography>
+            <Typography component="li" variant="body2"><strong>Health Metrics:</strong> Heart rate, HRV, blood oxygen (oxy-heart-rate), sleep respiratory rate, and sleep temperature derivations.</Typography>
+            <Typography component="li" variant="body2"><strong>Sleep:</strong> Sleep stages and classic sleep data.</Typography>
+            <Typography component="li" variant="body2"><strong>Heart Health:</strong> Electrocardiogram (raw waveform) and irregular rhythm notifications (AFib).</Typography>
+            <Typography component="li" variant="body2"><strong>Location:</strong> GPS trackpoints (collected only during active exercise).</Typography>
+            <Typography component="li" variant="body2"><strong>Settings:</strong> Timezone information (to accurately align your daily data).</Typography>
+          </Box>
+
+          <Typography variant="subtitle1" fontWeight={600} sx={{ mt: 3 }}>Managing your connection</Typography>
+          <Typography variant="body2" sx={{ mt: 1 }}>
+            Participation is entirely voluntary. If you wish to withdraw from the study or disconnect your Google Health account, please contact the study administration team at{' '}
+            <Link href={`mailto:${STUDY_ADMIN_EMAIL}`}>{STUDY_ADMIN_EMAIL}</Link>.
+          </Typography>
+
+          <Typography variant="subtitle1" fontWeight={600} sx={{ mt: 3 }}>Learn more about our work</Typography>
+          <Box component="ul" sx={{ pl: 3, mt: 1, mb: 0 }}>
+            <Typography component="li" variant="body2">
+              <Link href={GOOGLE_PRIVACY_POLICY_URL} target="_blank" rel="noopener noreferrer">How we handle your data (Google Privacy Policy)</Link>
+            </Typography>
+            <Typography component="li" variant="body2">
+              <Link href={RADAR_PUBLICATIONS_URL} target="_blank" rel="noopener noreferrer">View our peer-reviewed research publications</Link>
+            </Typography>
+          </Box>
+
+          <Box display={'flex'} flexDirection={'row'} justifyContent={'flex-end'} marginTop={3} gap={1}>
+            <Button onClick={handleAddMore} variant="outlined">Link another device</Button>
+            <Button onClick={handleReturn} variant="contained">Done</Button>
           </Box>
         </Box>
       </Grow>

--- a/app/_ui/portal/devicesPanel.tsx
+++ b/app/_ui/portal/devicesPanel.tsx
@@ -10,7 +10,7 @@ import { MarkdownContainer } from "../components/base/markdown";
 import { withBasePath } from "@/app/_lib/util/links";
 import { useRouter } from "next/navigation";
 import NextButton from "../components/base/nextButton";
-import { DeviceConnectedBanner } from "../components/device_connect/successBanner";
+import { DeviceConnectedBanner, GoogleHealthConnectedBanner } from "../components/device_connect/successBanner";
 import { ProtocolContext } from "@/app/_lib/study/protocol/provider.client";
 
 
@@ -83,6 +83,7 @@ export function DevicesPanel(props: DevicePanelProps) {
   if (device) {
     deviceConnectedName = devices.find(d => d.id == device)?.title ?? device
   }
+  const isGoogleHealth = (device ?? '').replace(/[_\s]/g, '').toLowerCase() == 'googlehealth'
 
   const title: string = task.options.title ?? "Connect Your Device"
   const description: string = task.options.description ?? "Please click on the device below which you would like to connect"
@@ -97,7 +98,11 @@ export function DevicesPanel(props: DevicePanelProps) {
         </Alert>
       </Box>
     ) : null}
-    {(device != undefined && !errorMsg) ? <DeviceConnectedBanner device={deviceConnectedName} onFinish={onSubmit} /> : null}
+    {(device != undefined && !errorMsg) ? (
+      isGoogleHealth
+        ? <GoogleHealthConnectedBanner onFinish={onSubmit} />
+        : <DeviceConnectedBanner device={deviceConnectedName} onFinish={onSubmit} />
+    ) : null}
     <Grid container spacing={2} gridAutoColumns={'3lf'} gridAutoFlow={"column"}>
       <Grid size={12}>
         <RadarCard>

--- a/app/_ui/portal/devicesPanel.tsx
+++ b/app/_ui/portal/devicesPanel.tsx
@@ -1,7 +1,7 @@
 "use client"
 import { Box, Container, Typography, Alert, AlertTitle } from "@mui/material"
 import Grid from '@mui/material/Grid2';
-import { ArmtMetadataInbuilt } from "@/app/_lib/study/protocol";
+import { ArmtMetadataInbuilt, ConnectDeviceConfirmation } from "@/app/_lib/study/protocol";
 import { usePathname, useSearchParams } from 'next/navigation'
 import React, { useContext, useEffect, useState } from "react";
 import { RadarDeviceCard } from "@/app/_ui/components/portal/deviceCard";
@@ -77,13 +77,14 @@ export function DevicesPanel(props: DevicePanelProps) {
   const task = (protocol.protocols
     .find((p) => ((p.metadata.type == 'inbuilt') && (p.metadata.inbuiltId == 'connect')))
     ?.metadata as ArmtMetadataInbuilt)
-  let devices = task.options.devices as {id: string, title: string, logo_src: string, description: string}[]
+  let devices = task.options.devices as {id: string, title: string, logo_src: string, description: string, confirmation?: ConnectDeviceConfirmation}[]
 
   let deviceConnectedName: string = ""
   if (device) {
     deviceConnectedName = devices.find(d => d.id == device)?.title ?? device
   }
   const isGoogleHealth = (device ?? '').replace(/[_\s]/g, '').toLowerCase() == 'googlehealth'
+  const confirmation = isGoogleHealth ? devices.find(d => d.id == 'google_health')?.confirmation : undefined
 
   const title: string = task.options.title ?? "Connect Your Device"
   const description: string = task.options.description ?? "Please click on the device below which you would like to connect"
@@ -99,8 +100,8 @@ export function DevicesPanel(props: DevicePanelProps) {
       </Box>
     ) : null}
     {(device != undefined && !errorMsg) ? (
-      isGoogleHealth
-        ? <GoogleHealthConnectedBanner onFinish={onSubmit} />
+      confirmation
+        ? <GoogleHealthConnectedBanner confirmation={confirmation} onFinish={onSubmit} />
         : <DeviceConnectedBanner device={deviceConnectedName} onFinish={onSubmit} />
     ) : null}
     <Grid container spacing={2} gridAutoColumns={'3lf'} gridAutoFlow={"column"}>


### PR DESCRIPTION
Adds the Google Health connect page with a prominent data-use disclosure and google compliant branding. After connecting, participants get a google specific confirmation covering what data is shared, what happens next, and how to withdraw, other sources keep the existing simple banner.